### PR TITLE
Propagate 'std' feature to dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,15 @@ documentation = "https://docs.rs/morton-encoding/"
 repository = "https://github.com/DoubleHyphen/morton-encoding"
 
 [dependencies]
-num-traits = "0.2"
-num = "0.2"
+num-traits = { version = "0.2", default-features = false }
+num = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 rand = "0.8"
 
 [features]
 default = ["std"]
-std = []
+std = [
+		"num-traits/std",
+		"num/std",
+]


### PR DESCRIPTION
It's currently impossible to use this crate with `nostd`, as both dependencies are build with their respective `std` feature. As far as I'm aware, there is no way to remove default flags from a transitive dependency.

This change removes the default features from both `num` and `num-traits` and adds the via the `std` feature.